### PR TITLE
Implement warning for unsupported bluetooth

### DIFF
--- a/Nod Emulator/Nod Emulator/NodBluetoothEmulator.h
+++ b/Nod Emulator/Nod Emulator/NodBluetoothEmulator.h
@@ -21,7 +21,7 @@
 #define GEST_SIZE 5
 #define BUTTON_SIZE 2
 
-@interface NodBluetoothEmulator : NSObject <CBPeripheralManagerDelegate>
+@interface NodBluetoothEmulator : NSObject <CBPeripheralManagerDelegate, UIAlertViewDelegate>
 
 @property CBPeripheralManager* periphMan;
 @property NSMutableArray* services;
@@ -29,6 +29,7 @@
 @property CBMutableCharacteristic* trans3DChar;
 @property CBMutableCharacteristic* gestChar;
 @property CBMutableCharacteristic* buttonChar;
+@property UIAlertView *bluetoothUnsupportedAlertView;
 
 +(id) sharedEmulator;
 -(void) sendOS2D: (NSData*) data;

--- a/Nod Emulator/Nod Emulator/NodBluetoothEmulator.m
+++ b/Nod Emulator/Nod Emulator/NodBluetoothEmulator.m
@@ -57,7 +57,7 @@
         }
         case CBPeripheralManagerStateUnsupported: {
             NSLog(@"peripheralStateChange: Unsupported");
-            // TODO: Give user feedback that Bluetooth is not supported.
+            [self warnForUnsupportedBluetooth];
             break;
         }
         case CBPeripheralManagerStateUnknown:
@@ -67,6 +67,7 @@
             break;
     }
 }
+
 
 -(void) disableServices
 {
@@ -282,6 +283,23 @@ didSubscribeToCharacteristic:(CBCharacteristic *)characteristic
     [self.periphMan updateValue:updatedValue
               forCharacteristic:self.buttonChar onSubscribedCentrals:nil];
 }
+
+
+- (void)warnForUnsupportedBluetooth
+{
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Bluetooth Unsupported" message:@"Nod Emulator requires Bluetooth.  Please try running the app again on a device that supports Bluetooth." delegate:self cancelButtonTitle:@"OK" otherButtonTitles:nil];
+    [alertView show];
+    self.bluetoothUnsupportedAlertView = alertView;
+}
+
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
+{
+    if (alertView == self.bluetoothUnsupportedAlertView) {
+        exit(0); // Bluetooth is unsupported; self-destruct.
+    }
+}
+
 
 @end
 


### PR DESCRIPTION
I was playing around with the SDK today and noticed that the Nod emulator crashes in the iOS simulator with a somewhat confusing error.  I found a TODO in the code for warning the user when this happens, so I went ahead and implemented it to improve the experience.
