### PR TITLE
Nod emulator: assign target actions via IBAction

### DIFF
--- a/Nod Emulator/Nod Emulator/Base.lproj/Main_iPhone.storyboard
+++ b/Nod Emulator/Nod Emulator/Base.lproj/Main_iPhone.storyboard
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6154.17" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6153.11"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Help View Controller-->
         <scene sceneID="FJs-9L-a60">
             <objects>
-                <viewController id="bhf-WC-Nc5" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="HelpViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="bhf-WC-Nc5" userLabel="Help View Controller" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="5Nb-oX-JNJ"/>
                         <viewControllerLayoutGuide type="bottom" id="m3D-D9-ZVu"/>
@@ -28,7 +28,7 @@
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Welcome to the Nod Emulator" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7N6-T1-4QY">
                                 <rect key="frame" x="35" y="73" width="231" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="This application is designed to emulate the" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lhe-Z9-Tuf">
@@ -149,10 +149,10 @@
             </objects>
             <point key="canvasLocation" x="137" y="-423"/>
         </scene>
-        <!--View Controller-->
+        <!--Main View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController id="vXZ-lx-hvc" customClass="ViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MainViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="vXZ-lx-hvc" userLabel="Main View Controller" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
@@ -170,6 +170,9 @@
                                 <state key="normal" title="3D Rotation">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="enableTrans3D" destination="vXZ-lx-hvc" eventType="touchUpInside" id="AIg-F5-tkV"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BcF-5J-ozz">
                                 <rect key="frame" x="234" y="518" width="62" height="30"/>
@@ -185,27 +188,39 @@
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fFt-Nq-NR4">
                                 <rect key="frame" x="55" y="83" width="39" height="40"/>
-                                <state key="normal" image="BlueButton.png">
+                                <state key="normal" title="L Tact" image="BlueButton.png">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="leftTactPressed" destination="vXZ-lx-hvc" eventType="touchUpInside" id="xZi-1L-hqi"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SGf-0g-eCI">
                                 <rect key="frame" x="222" y="83" width="41" height="40"/>
-                                <state key="normal" image="BlueButton.png">
+                                <state key="normal" title="R Tact" image="BlueButton.png">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="rightTactPressed" destination="vXZ-lx-hvc" eventType="touchUpInside" id="vHk-pr-8bj"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pqv-kH-bcK">
                                 <rect key="frame" x="35" y="137" width="40" height="40"/>
-                                <state key="normal" image="BlueButton.png">
+                                <state key="normal" title="L Touch" image="BlueButton.png">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="leftTouchPressed" destination="vXZ-lx-hvc" eventType="touchUpInside" id="aGJ-wL-36O"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jql-rN-eV9">
                                 <rect key="frame" x="245" y="137" width="40" height="40"/>
                                 <state key="normal" title="R Touch" image="BlueButton.png">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="rightTouchPressed" destination="vXZ-lx-hvc" eventType="touchUpInside" id="WmC-Ic-AKG"/>
+                                </connections>
                             </button>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e4k-BY-wIL" customClass="SliderView">
                                 <rect key="frame" x="95" y="81" width="131" height="35"/>
@@ -224,11 +239,11 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <connections>
-                        <outlet property="LTact" destination="fFt-Nq-NR4" id="4pf-Ho-7qr"/>
-                        <outlet property="LTouch" destination="Pqv-kH-bcK" id="vQg-yd-zQc"/>
-                        <outlet property="RTact" destination="SGf-0g-eCI" id="xrX-bE-3pZ"/>
-                        <outlet property="RTouch" destination="jql-rN-eV9" id="Bb4-Ug-vmy"/>
-                        <outlet property="quatBut" destination="IWi-Wr-bXc" id="pHg-3M-iaE"/>
+                        <outlet property="LTact" destination="fFt-Nq-NR4" id="4UC-5M-SI0"/>
+                        <outlet property="LTouch" destination="Pqv-kH-bcK" id="sMv-8f-djV"/>
+                        <outlet property="RTact" destination="SGf-0g-eCI" id="RYZ-Mo-3Pq"/>
+                        <outlet property="RTouch" destination="jql-rN-eV9" id="bga-JB-9qp"/>
+                        <outlet property="quatBut" destination="IWi-Wr-bXc" id="bsX-w3-Ena"/>
                         <outlet property="sliderView" destination="e4k-BY-wIL" id="23x-Jj-qiF"/>
                         <outlet property="trackView" destination="Kff-Nk-Cf9" id="xlD-TS-R5M"/>
                     </connections>
@@ -237,10 +252,10 @@
             </objects>
             <point key="canvasLocation" x="137" y="234"/>
         </scene>
-        <!--View Controller-->
+        <!--Gestures View Controller-->
         <scene sceneID="MIa-Af-Fuf">
             <objects>
-                <viewController id="Ctn-5U-uhd" customClass="ViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="GesturesViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Ctn-5U-uhd" userLabel="Gestures View Controller" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="9BP-1X-Aag"/>
                         <viewControllerLayoutGuide type="bottom" id="oJR-x9-ahl"/>
@@ -258,6 +273,9 @@
                                     <color key="titleColor" red="0.2941176593" green="0.2941176593" blue="0.2941176593" alpha="1" colorSpace="deviceRGB"/>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="swipedUp" destination="Ctn-5U-uhd" eventType="touchUpInside" id="Xcj-a6-3P7"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F4Q-Tp-ttF">
                                 <rect key="frame" x="203" y="256" width="107" height="56"/>
@@ -265,6 +283,9 @@
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="swipedRight" destination="Ctn-5U-uhd" eventType="touchUpInside" id="ymz-Sf-UvA"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8qx-sN-6Sf">
                                 <rect key="frame" x="9" y="256" width="106" height="56"/>
@@ -272,6 +293,9 @@
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="swipedLeft" destination="Ctn-5U-uhd" eventType="touchUpInside" id="veS-lb-VUG"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zmv-6z-2fl">
                                 <rect key="frame" x="116" y="333" width="88" height="215"/>
@@ -279,6 +303,9 @@
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="swipedDown" destination="Ctn-5U-uhd" eventType="touchUpInside" id="g8e-zB-RK6"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EXo-Rt-iKr">
                                 <rect key="frame" x="244" y="20" width="56" height="39"/>
@@ -295,6 +322,9 @@
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="twistedLeft" destination="Ctn-5U-uhd" eventType="touchUpInside" id="c67-OA-FJ5"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dBy-Je-llh">
                                 <rect key="frame" x="208" y="87" width="112" height="110"/>
@@ -302,18 +332,13 @@
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="twistedRight" destination="Ctn-5U-uhd" eventType="touchUpInside" id="X7C-bx-PpP"/>
+                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
-                    <connections>
-                        <outlet property="swipeDown" destination="zmv-6z-2fl" id="Eaq-1l-eYT"/>
-                        <outlet property="swipeLeft" destination="8qx-sN-6Sf" id="uot-jB-Nma"/>
-                        <outlet property="swipeRight" destination="F4Q-Tp-ttF" id="mBn-tT-aBb"/>
-                        <outlet property="swipeUp" destination="9RN-Oe-Amy" id="GD4-6r-4Tv"/>
-                        <outlet property="twistLeft" destination="NKr-yH-aOp" id="c97-UX-wm6"/>
-                        <outlet property="twistRight" destination="dBy-Je-llh" id="TN8-5C-wSa"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MTw-hb-b6n" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -337,6 +362,6 @@
         <simulatedScreenMetrics key="destination" type="retina4"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
-        <segue reference="PEf-o2-EUy"/>
+        <segue reference="1Gp-do-k4Q"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Nod Emulator/Nod Emulator/ViewController.h
+++ b/Nod Emulator/Nod Emulator/ViewController.h
@@ -21,13 +21,7 @@
 @property (weak, nonatomic) IBOutlet TouchView *trackView;
 @property (weak, nonatomic) IBOutlet UIButton *quatBut;
 @property (weak, nonatomic) IBOutlet UIButton *eulerBut;
-@property (weak, nonatomic) IBOutlet UIButton *swipeUp;
-@property (weak, nonatomic) IBOutlet UIButton *swipeRight;
-@property (weak, nonatomic) IBOutlet UIButton *swipeDown;
-@property (weak, nonatomic) IBOutlet UIButton *swipeLeft;
 @property (weak, nonatomic) IBOutlet SliderView *sliderView;
-@property (weak, nonatomic) IBOutlet UIButton *twistLeft;
-@property (weak, nonatomic) IBOutlet UIButton *twistRight;
 @property CMMotionManager* motionManager;
 
 -(void) leftSlidePressed;

--- a/Nod Emulator/Nod Emulator/ViewController.m
+++ b/Nod Emulator/Nod Emulator/ViewController.m
@@ -36,32 +36,6 @@
     self.sliderView.parent = self;
     self.trackView.delegate = self;
     self.NBE = [NodBluetoothEmulator sharedEmulator];
-    [self.LTouch addTarget:self action:@selector(leftTouchPressed)
-          forControlEvents:UIControlEventTouchDown];
-    [self.RTouch addTarget:self action:@selector(rightTouchPressed)
-          forControlEvents:UIControlEventTouchDown];
-    [self.LTact addTarget:self action:@selector(leftTactPressed)
-         forControlEvents:UIControlEventTouchDown];
-    [self.RTact addTarget:self action:@selector(rightTactPressed)
-         forControlEvents:UIControlEventTouchDown];
-    [self.LSlide addTarget:self action:@selector(leftSlidePressed)
-          forControlEvents:UIControlEventTouchDown];
-    [self.RSlide addTarget:self action:@selector(rightSlidePressed)
-          forControlEvents:UIControlEventTouchDown];
-    [self.quatBut addTarget:self action:@selector(enableTrans3D)
-           forControlEvents:UIControlEventTouchDown];
-    [self.swipeUp addTarget:self action:@selector(swipedUp)
-           forControlEvents:UIControlEventTouchDown];
-    [self.swipeDown addTarget:self action:@selector(swipedDown)
-             forControlEvents:UIControlEventTouchDown];
-    [self.swipeLeft addTarget:self action:@selector(swipedLeft)
-             forControlEvents:UIControlEventTouchDown];
-    [self.swipeRight addTarget:self action:@selector(swipedRight)
-              forControlEvents:UIControlEventTouchDown];
-    [self.twistRight addTarget:self action:@selector(twistedRight)
-              forControlEvents:UIControlEventTouchDown];
-    [self.twistLeft addTarget:self action:@selector(twistedLeft)
-              forControlEvents:UIControlEventTouchDown];
 }
 
 +(UIColor*)colorWithHexString:(NSString*)hex
@@ -124,7 +98,7 @@ short tact1 = 0;
  *                  tact1 -> right tact
  */
 
-- (void) leftTouchPressed
+- (IBAction)leftTouchPressed
 {
     if(touch0 == BUTTON_UNUSED || touch0 == BUTTON_UP)
     {
@@ -152,8 +126,7 @@ short tact1 = 0;
 }
 
 
-
-- (void) rightTouchPressed
+- (IBAction)rightTouchPressed
 {
     if(touch1 == BUTTON_UNUSED || touch1 == BUTTON_UP)
     {
@@ -180,7 +153,7 @@ short tact1 = 0;
     [self.NBE sendButton:temp];
 }
 
-- (void) SlideHoldPressed
+- (IBAction) SlideHoldPressed
 {
     if(touch2 == BUTTON_UNUSED || touch2 == BUTTON_UP)
     {
@@ -203,7 +176,8 @@ short tact1 = 0;
     [self.NBE sendButton:temp];
 }
 
-- (void) leftTactPressed
+
+- (IBAction) leftTactPressed
 {
     if(tact0 == BUTTON_UNUSED || tact0 == BUTTON_UP)
     {
@@ -230,7 +204,8 @@ short tact1 = 0;
     [self.NBE sendButton:temp];
 }
 
-- (void) rightTactPressed
+
+- (IBAction) rightTactPressed
 {
     if(tact1 == BUTTON_UNUSED || tact1 == BUTTON_UP)
     {
@@ -257,7 +232,7 @@ short tact1 = 0;
     [self.NBE sendButton:temp];
 }
 
--(void) leftSlidePressed
+-(IBAction)leftSlidePressed
 {
     NSDictionary* retDic = @{GEST_OPCODE : @G_OP_SCROLL,
                             GEST_DATA : @SLIDE_LEFT,
@@ -266,7 +241,7 @@ short tact1 = 0;
     NSData* temp = [NSData dataWithBytes:bytes length:GEST_SIZE];
     [self.NBE sendGesture:temp];
 }
--(void) rightSlidePressed
+-(IBAction)rightSlidePressed
 {
     NSDictionary* retDic = @{GEST_OPCODE : @G_OP_SCROLL,
                              GEST_DATA : @SLIDE_RIGHT,
@@ -290,7 +265,7 @@ short tact1 = 0;
 }
 
 bool trans3DEnabled = false;
--(void) enableTrans3D
+- (IBAction) enableTrans3D
 {
     if(!trans3DEnabled)
     {
@@ -333,7 +308,8 @@ bool trans3DEnabled = false;
 
 }
 
-- (void) swipedUp
+
+- (IBAction) swipedUp
 {
     NSDictionary* retDic = @{GEST_OPCODE: @G_OP_DIRECTION,
                              GEST_DATA : @GUP,
@@ -343,7 +319,7 @@ bool trans3DEnabled = false;
     [self.NBE sendGesture:temp];
 }
 
-- (void) swipedDown
+- (IBAction) swipedDown
 {
     NSDictionary* retDic = @{GEST_OPCODE: @G_OP_DIRECTION,
                              GEST_DATA : @GDOWN,
@@ -353,7 +329,7 @@ bool trans3DEnabled = false;
     [self.NBE sendGesture:temp];
 }
 
-- (void) swipedLeft
+- (IBAction) swipedLeft
 {
     NSDictionary* retDic = @{GEST_OPCODE: @G_OP_DIRECTION,
                              GEST_DATA : @GLEFT,
@@ -363,7 +339,7 @@ bool trans3DEnabled = false;
     [self.NBE sendGesture:temp];
 }
 
-- (void) swipedRight
+- (IBAction) swipedRight
 {
     NSDictionary* retDic = @{GEST_OPCODE: @G_OP_DIRECTION,
                              GEST_DATA : @GRIGHT,
@@ -373,7 +349,7 @@ bool trans3DEnabled = false;
     [self.NBE sendGesture:temp];
 }
 
-- (void) twistedLeft
+- (IBAction) twistedLeft
 {
     NSDictionary* retDic = @{GEST_OPCODE: @G_OP_DIRECTION,
                              GEST_DATA : @GCW,
@@ -383,7 +359,7 @@ bool trans3DEnabled = false;
     [self.NBE sendGesture:temp];
 }
 
-- (void) twistedRight
+- (IBAction) twistedRight
 {
     NSDictionary* retDic = @{GEST_OPCODE: @G_OP_DIRECTION,
                              GEST_DATA : @GCCW,


### PR DESCRIPTION
Removes the programmatic `addTarget:action:...` statements from viewDidLoad in the emulator view controller, replacing them with IBActions linked directly to interface builder elements.  In my opinion this is a better way to link the methods to their corresponding UI buttons, since it saves you from having to read through a lot of repeated code in the implementation.
